### PR TITLE
Mostrar infoTributaria en retenciones y estandarizar nombre de cabeceras

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sri-xml-2-json",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/documents/settlement.document.ts
+++ b/src/documents/settlement.document.ts
@@ -30,7 +30,7 @@ export class SettlementDocument implements IDocument {
         transform: mappingInfoTax,
         dependsOn: liquidacionCompra.infoTributaria,
       },
-      settlementInfo: {
+      documentInfo: {
         transform: this.transformSettlementInfo,
         dependsOn: liquidacionCompra,
       },

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,10 +144,10 @@ describe('sri-xml-2-json', () => {
       const ride = new Ride(fixtures.PURCHASE_SETTLEMENT);
       const result = await ride.convertToJson();
       const responseParsed = JSON.parse(result);
+      console.dir(responseParsed, { depth: null });
       expect(responseParsed).toHaveProperty('version');
-
       expect(responseParsed).toHaveProperty('infoTributaria');
-      expect(responseParsed).toHaveProperty('infoLiquidacionCompra');
+      expect(responseParsed).toHaveProperty('infoDocumento');
       expect(responseParsed).toHaveProperty('fechaAutorizacion');
       expect(responseParsed).toHaveProperty('estado');
     });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -144,7 +144,7 @@ describe('sri-xml-2-json', () => {
       const ride = new Ride(fixtures.PURCHASE_SETTLEMENT);
       const result = await ride.convertToJson();
       const responseParsed = JSON.parse(result);
-      console.dir(responseParsed, { depth: null });
+
       expect(responseParsed).toHaveProperty('version');
       expect(responseParsed).toHaveProperty('infoTributaria');
       expect(responseParsed).toHaveProperty('infoDocumento');

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -87,7 +87,7 @@ export const retentionPropertyMap = {
 export const settlementPropertyMap = {
   versionInfo: 'version',
   taxInfo: 'infoTributaria',
-  settlementInfo: 'infoLiquidacionCompra',
+  documentInfo: 'infoDocumento',
   additionalInfo: 'infoAdicional',
   products: 'productos',
   details: 'detalles',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,13 +155,32 @@ export const transformTaxInfo = (receipt: any): object | undefined => {
     return undefined;
   }
 
-  const { ambiente, tipoEmision, ruc, claveAcceso } = receipt.infoTributaria;
+  const {
+    ambiente,
+    tipoEmision,
+    ruc,
+    claveAcceso,
+    codDoc,
+    razonSocial,
+    nombreComercial,
+    estab,
+    ptoEmi,
+    secuencial,
+    dirMatriz,
+  } = receipt.infoTributaria;
 
   return {
     ambiente,
     tipoEmision,
     ruc,
     claveAcceso,
+    codDoc,
+    razonSocial,
+    nombreComercial,
+    estab,
+    ptoEmi,
+    secuencial,
+    dirMatriz,
   };
 };
 


### PR DESCRIPTION
En este PR se muestra el resto de información del nodo infoTributaria en los documentos de tipo retenciones, emitido y recibido, donde no se estaba mostrando datos como el código del documento entre otros.
Además de estandarizar el nombre de cabeceras para el caso de retenciones pues antes se llamaba su cabecera 'infoLiquidacionCompra', cuando en el resto de documentos se llama 'infoDocumento' y la idea es tener eso igual para todos los documentos.
 
 *Nota-> los tests siguen pasando todos de manera exitosa
 
![image](https://github.com/user-attachments/assets/400d5fc7-a8b5-4a5a-ba36-d9cb15221b95)

