### PR TITLE
Remover integer en access key en Liquidaciones y remover info duplicada

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sri-xml-2-json",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/documents/settlement.document.ts
+++ b/src/documents/settlement.document.ts
@@ -13,6 +13,7 @@ import {
   parseNumberInObject,
   removeUnwantedProperties,
   mapTaxInfo,
+  transformTaxInfo,
 } from '../utils';
 import { IDocument } from './document.interface';
 
@@ -20,15 +21,11 @@ export class SettlementDocument implements IDocument {
   transform(xml: any): object {
     const { liquidacionCompra } = xml;
 
-    if (!liquidacionCompra || !liquidacionCompra.infoTributaria) {
-      throw new Error('Missing infoTributaria in settlement document');
-    }
-
     // Transformaciones específicas del documento
     const specificTransformations = {
       taxInfo: {
-        transform: mappingInfoTax,
-        dependsOn: liquidacionCompra.infoTributaria,
+        transform: transformTaxInfo,
+        dependsOn: liquidacionCompra,
       },
       documentInfo: {
         transform: this.transformSettlementInfo,
@@ -69,11 +66,10 @@ export class SettlementDocument implements IDocument {
     removeUnwantedProperties(newSettlement, [
       removePropertyMap.signature,
       removePropertyMap.dollarSign,
+      removePropertyMap.settlementInfo,
     ]);
 
-    const settlementParser = parseNumberInObject(newSettlement);
-
-    return settlementParser;
+    return newSettlement;
   }
 
   private transformSettlementInfo(settlement: any) {

--- a/src/mapping.ts
+++ b/src/mapping.ts
@@ -102,6 +102,7 @@ export const removePropertyMap = {
   totalWithTaxes: 'totalConImpuestos',
   creditNoteInfo: 'infoNotaCredito',
   retentionInfo: 'infoCompRetencion',
+  settlementInfo: 'infoLiquidacionCompra',
 };
 
 export const commonPropertyMap = {


### PR DESCRIPTION
En este PR se agregó el error de mostrar un integer en el access key de las liquidaciones de compra, se mostraba de esta manera: 1.4052024030991355e+48, en lugar de '1908202403091651386400120010020000005891234567816'.

Además se refactorizaron los métodos de documentInfo y eliminar un nodo innecesario

*Error corregido
![image](https://github.com/user-attachments/assets/b99700ef-c8ac-4206-ad45-5dd0fbb74b7e)
